### PR TITLE
Fix Typo: 'RUnning' to 'Running' in chainweb-get-started.md

### DIFF
--- a/docs/guides/nodes/chainweb-get-started.md
+++ b/docs/guides/nodes/chainweb-get-started.md
@@ -35,7 +35,7 @@ Most `chainweb-node` software runs on Linux or macOS with AMD64 architectures.
 If you want to run a Chainweb node on Linux or macOS with ARM64 architecture, you'll need to build the binaries yourself from the source code.
 You might experience some unexpected behavior when running a node on ARM64 architecture.
 Note that you should not configure **mining** for nodes on ARM64 architecture.
-RUnning a mining node on ARM64 architecture could cause your node to fork from the network.
+Running a mining node on ARM64 architecture could cause your node to fork from the network.
 
 If you want to run a Chainweb node on Microsoft Windows, you should note that this isn't a supported configuration and requires you to install the latest Windows Services for Linux (WSL) software.
 If you choose to proceed after installing WSL, you can install the `chainweb-node` software in the WSL virtual environment rather than using the native Windows operating system. 


### PR DESCRIPTION
Corrects a minor grammatical error in the documentation:

Changed 'RUnning' to 'Running' in chainweb-get-started.md (line 38).