### PR TITLE
Enhance Transaction Signing Examples with "Sign with a public and secret key pair"

### DIFF
--- a/docs/reference/kadena-client.md
+++ b/docs/reference/kadena-client.md
@@ -922,6 +922,16 @@ To sign with one key pair:
 ```typescript
 const signWithKeypair = createSignWithKeypair({ publicKey, secretKey });
 
+const tx = Pact.builder
+  .execution(Pact.modules.coin.transfer(senderAccount, receiverAccount, amount))
+  .addSigner(senderKey, (signFor) => [
+    signFor('coin.GAS'),
+    signFor('coin.TRANSFER', senderAccount, receiverAccount, amount),
+  ])
+  .setMeta({ chainId: '0', senderAccount })
+  .setNetworkId(NETWORK_ID)
+  .createTransaction();
+
 const signedTx = signWithKeypair(tx);
 ```
 


### PR DESCRIPTION
This PR improves the transaction signing documentation by adding more verbose examples using `Sign with a public and secret key pair`. Previously, the signing examples with a public and secret key pair lacked sufficient details on the signing process. The new examples demonstrate:

- Using public and secret key pair for  transaction signing with `const signWithKeypair = createSignWithKeypair({ publicKey, secretKey });`

- Providing a clearer distinction between key pair signing, `createEckoWalletQuicksign`  and  `EckoWallet` signing for better clarity.
These enhancements ensure a more comprehensive understanding of transaction signing within the ecosystem.