### PR TITLE
Fix minor spelling and grammatical errors across documentation

### DIFF
--- a/docs/coding-projects/hello-world.md
+++ b/docs/coding-projects/hello-world.md
@@ -335,7 +335,7 @@ To deploy the contract on the Kadena test network using Chainweaver:
 
    ![You must have an account with funds on a chain to continue](/img/deploy-testnet-account.png)
 
-   If you don't have keys and at least one account on any chain on the test network,you need to generate keys, create an account, and fund the account on at least one chain before continuing.
+   If you don't have keys and at least one account on any chain on the test network, you need to generate keys, create an account, and fund the account on at least one chain before continuing.
 
 6. Click **Contracts** in the Chainweaver navigation pane, then click **Open File** to select the contract you want to deploy.
 

--- a/docs/guides/contracts/deploy-a-contract.md
+++ b/docs/guides/contracts/deploy-a-contract.md
@@ -34,7 +34,7 @@ To deploy a smart contract with a `curl` command:
    secret: 682ce35a77eece5060537632423de96b965136bd7739c5064903612c0b300608
    ```
 
-   Use the public key to create and fund an account on at least one chain in the development, test, or main network,
+   Use the public key to create and fund an account on at least one chain in the development, test, or main network.
    For example: 
    
    - Use `kadena account add` to add an account for the public key manually in the development network and one or more chains.
@@ -195,7 +195,7 @@ To deploy a smart contract using `kadena-cli`:
 
 ## Using the Kadena client library
 
-If you prefer to work with JavaScript, you can use the `@kadena/client` library to write you own scripts to deploy contracts and perform other tasks. 
+If you prefer to work with JavaScript, you can use the `@kadena/client` library to write your own scripts to deploy contracts and perform other tasks. 
 The `@kadena/client` library implements a TypeScript-based API for interacting with smart contracts and Chainweb nodes. 
 The library provides functions that simplify building transactions with Pact commands and connecting to blockchain nodes.
 You should note that creating the client connection is separate from using the `Pact.builder` function to construct transactions.

--- a/docs/guides/dev-with-cli.md
+++ b/docs/guides/dev-with-cli.md
@@ -78,7 +78,7 @@ The `kadena-cli` package is designed to simplify setting up a development enviro
 Its intuitive commands prompt you for all of the information required to complete tasks, like creating accounts or managing keys.
 Responding to prompts interactively is typically the best approach when getting started, eliminating the need to look up or remember the arguments required for the action you want to perform.
 
-To start using the CLI in interactive Mode, you simply type _kadena_ followed by a _subject_ that describes the type of information you want to work with and a _verb_ to describe what you want to do.
+To start using the CLI in interactive mode, you simply type _kadena_ followed by a _subject_ that describes the type of information you want to work with and a _verb_ to describe what you want to do.
 You don't need to specify any additional arguments or options.
 
 For example, if you want to add a new wallet but aren't sure of all the required flags and
@@ -317,7 +317,7 @@ To fund an onchain account:
    ```
 
 1. Enter an amount, then press Return.
-2. For example:
+   For example:
 
    ```bash
    ? Enter an amount: 2
@@ -373,7 +373,7 @@ To fund an onchain account:
    kadena account fund --account="pistolas-kda" --amount="2" --network="devnet" --chain-ids="all" --deployFaucet
    ```
 
-1. Verify account information for the account for a subset of by chains.
+1. Verify account information for the account for a subset of chains.
    For example, to see account details for chains 1, 2, and 3 formatted as JSON output, you can specify command-line options similar to the following:
 
    ```bash
@@ -789,7 +789,7 @@ To set the default network:
    kadena network set-default --network="devnet" --confirm
    ```
 
-   After settings default network, you won't be prompting to select a network when running other commands.
+   After setting the default network, you won't be prompted to select a network when running other commands.
    If you want to remove the default network from your configuration, run the following command:
 
    ```bash
@@ -827,10 +827,10 @@ To create a new project from a template:
 
 1. Open a terminal shell on the computer where you've installed the `kadena-cli` package.
 2. Enter `kadena dapp create <app-name>` on the command line to create a new project directory with the name you specify.
-   For example, to create a project names my-to-do:
+   For example, to create a project named my-to-do:
 
    ```shell
-   kadena dapp add my-to-do
+   kadena dapp create my-to-do
    ```
 
    Because you're running the command interactively, you are prompted to select a template.

--- a/docs/pact-5/general/enforce-guard.md
+++ b/docs/pact-5/general/enforce-guard.md
@@ -31,7 +31,7 @@ The `enforce-guard` function returns a boolean value indicating whether the cond
 
 ## Examples
 
-The following example demonstrates using the keyset guard named `admin-keyset` to enforce specific signing requirements defined in the keyset predicate function, for example with the `keys-all` or `keys-2`predicate:
+The following example demonstrates using the keyset guard named `admin-keyset` to enforce specific signing requirements defined in the keyset predicate function, for example with the `keys-all` or `keys-2` predicate:
 
 ```pact
 (enforce-guard 'admin-keyset)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,7 +34,7 @@ If you have everything you need, you can set up your development environment and
 ## Install Pact
 
 The Pact smart contract programming language is specifically designed for writing [smart contracts](/resources/glossary) to run safely and efficiently on the Kadena blockchain network.
-Follow the appropriate instructions for your operating system to Pact.
+Follow the appropriate instructions for your operating system to install Pact.
 
 - [Install Pact on Linux](/smart-contracts/install/linux)
 - [Install Pact on macOS](/smart-contracts/install/macos)
@@ -81,13 +81,13 @@ For command-line reference information, see [kadena-cli command reference](/refe
 You can now write and execute a simple `greeting` smart contract using the Pact smart contract programming language and the Pact interactive interpreter.
 
 1. Open a terminal shell on your computer.
-3. Start the Pact interpreter that you installed in the first step by running the following command:
+2. Start the Pact interpreter that you installed in the first step by running the following command:
 
    ```bash
    pact
    ```
 
-2. Copy and paste the following simple `greeting` module code, then press return:
+3. Copy and paste the following simple `greeting` module code, then press return:
 
    ```pact
    (module greeting GOVERNANCE
@@ -104,7 +104,7 @@ You can now write and execute a simple `greeting` smart contract using the Pact 
    "Loaded module greeting, hash f1yyXqj5HstOni1QdZmuagUJXbu72VmYiwXua7Vp4-0"
    ```
 
-3. Call the `say-hello` function with a string similar to the following:
+4. Call the `say-hello` function with a string similar to the following:
 
    ```pact
    (say-hello "Pistolas")

--- a/docs/reference/exchange-integration.md
+++ b/docs/reference/exchange-integration.md
@@ -8,7 +8,7 @@ sidebar_position: 5
 # Exchange integration guide
 
 This guide provides a quick reference for how to perform the most common tasks when an exchange or a similar application needs to interact with the Kadena blockchain.
-The information is this guide is similar to topics covered elsewhere in the documentation.
+The information in this guide is similar to topics covered elsewhere in the documentation.
 For example, you can see similar information in the following topics:
 
 - [Common task quick reference](/guides/howto-quick-ref)
@@ -97,7 +97,7 @@ For example, you can create keys and accounts by using any of the following wall
 1. Open [Chainweaver v3](https://wallet.kadena.io) and click **Add new profile** to create a wallet or **Recover your wallet** to import information from a backup file or recovery phrase.
    
    If creating a new wallet, type a **Profile name** and select a security method.
-   If recovering a wallet, provide the backup file or recovery phase to import keys and accounts.
+   If recovering a wallet, provide the backup file or recovery phrase to import keys and accounts.
    
    After creating or importing the wallet, the list of your assets on the Kadena **Mainnet** network is displayed by default.
    You can change the current network to **Testnet** or add another network by clicking **Settings**.
@@ -367,7 +367,7 @@ if (response.result.status === 'failure') {
 const gasEstimation = response.gas;
 ```
 
-## Listens for events
+## Listen for events
 
 There are several ways you can listen for events emitted by transactions that are executed on the blockchain.
 For example, you can listen for `coin.TRANSFER` events in the following ways:
@@ -384,6 +384,6 @@ package.
 
 As an exchange, it is particularly important for you to monitor node operations and network activity.
 If you notice suspicious transactions or are informed about unusual transaction activity, you should work with mining node operators and pool node operators to determine if the transaction is preventing other transactions from being processed, consuming excessive resources, or causing any nodes to fail.
-Often, adjusting transaction fees can mitigate transaction processing delays and minimize the affect for end users who are submitting transactions.
+Often, adjusting transaction fees can mitigate transaction processing delays and minimize the effect for end users who are submitting transactions.
 
 If the network experiences an incident affecting transaction processing, you should pause all deposit and withdrawal activity until normal operations resume.

--- a/docs/resources/contribute-doc.md
+++ b/docs/resources/contribute-doc.md
@@ -115,6 +115,7 @@ To create a working branch:
 
    ```code
    git switch -c lola-pistola/typo-reference-db-functions
+   ```
 
 4. Open the file you want to fix in a code editor and make the appropriate changes for the issue you are trying to address.
 

--- a/docs/smart-contracts/basic-concepts.md
+++ b/docs/smart-contracts/basic-concepts.md
@@ -9,7 +9,7 @@ description: "Get familiar with important Kadena blockchain and Pact language co
 
 The main purpose of a blockchain is to record **transactions**.
 Typically, transactions are business events that transfer some form of digital asset from one owner or entity to another.
-Through the use of modern **cryptography**, a blockchain can provides guarantees about the authenticity and integrity of the transactions recorded without relying on any central authority or under the control of any government, corporation, or other institution.
+Through the use of modern **cryptography**, a blockchain can provide guarantees about the authenticity and integrity of the transactions recorded without relying on any central authority or under the control of any government, corporation, or other institution.
 
 The **decentralized** nature of the blockchain depends on having its computational resources distributed across many individual computers.
 The individual computers in the network—called **nodes**—run the blockchain software and communicate with each other as a peer-to-peer (P2P) network using the internet and publicly-accessible IP addresses. 
@@ -20,7 +20,7 @@ Nodes provide the bandwidth, processors, memory, and storage capacity to handle 
 The method that a blockchain uses to validate transactions, insert transactions into blocks, and submit blocks to continue the chain is called its **consensus model** or **consensus algorithm**. 
 For the Kadena blockchain, the method of adding new blocks to the blockchain is a variation of a **proof of work** consensus model used by Bitcoin.
 With the proof-of-work consensus model, the first node to solve a computational problem for a transaction adds the transaction to a block.
-As new transaction are added to blocks and new blocks are produced, all of the nodes in the network attempt to stay in synch with each other so that there's a consistent view of the blockchain state.
+As new transactions are added to blocks and new blocks are produced, all of the nodes in the network attempt to stay in sync with each other so that there's a consistent view of the blockchain state.
 
 The computers used to solve the mathematical problems that validate transactions typically run specialized hardware and are commonly referred to as **miners** because they earn rewards for the work they do to keep the chain going.
 The rewards take the form of KDA tokens that are deposited in accounts owned by the node operators.
@@ -33,7 +33,7 @@ Networks that rely on a proof-of-work consensus model provide security and decen
 - The number of transactions they can process.
 - The speed at which they can process transactions.
 - The energy consumption required to validate transactions.
-- The high cost of transaction fees when the network in busy.
+- The high cost of transaction fees when the network is busy.
   
 These factors have limited the effectiveness of blockchain networks to handle modern economic activity. 
 
@@ -80,7 +80,7 @@ Individual modules are often self-contained logical units that implement a relat
 Keysets define authorization rules for smart contracts. 
 They often determine who can access specific functions in a program and the keys required to sign specific transactions.
 Capabilities define specific privileges or permissions that must be granted or acquired to perform specific operations within a section of code.
-Guards provide to enforce specific conditions, including that required keyset is being used or a specific capability token has been granted.
+Guards provide a way to enforce specific conditions, including that a required keyset is being used or a specific capability token has been granted.
 A keyset is itself a type of guard.
 
 ## Cross chain and multi-step transactions 
@@ -105,7 +105,7 @@ As a general rule, the transaction that you use to deploy a contract on the bloc
 
 When contracts are initialized on the blockchain, they identify a [namespace](/resources/glossary#namespace) that provides context for the contract code and a unique prefix for modules and interfaces defined in the contract.
 Modules contain the main business logic for the application or service you want to deploy.
-Interfaces provide access to constant definitions and typed function signatures that are defined outside of a module to be implemented an used in a module.
+Interfaces provide access to constant definitions and typed function signatures that are defined outside of a module to be implemented and used in a module.
 Deploying a contract also requires you to define one or more authorization [keysets](/resources/glossary#keyset) that have administrative control over the contract modules and tables. 
 Keysets that are defined as data in the runtime environment are then stored in the global keyset database.
 
@@ -124,11 +124,11 @@ There's no difference in how the code itself is evaluated.
 
 In general, querying data that's stored on the blockchain isn't considered a business event where execution and performance are more critical.
 In addition, queries can often involve larger data payloads that could introduce overhead, bandwidth, and latency issues.
-To reduce the impact of queries on network operations, queries are handles as _local execution requests_ on the node receiving the message. 
+To reduce the impact of queries on network operations, queries are handled as _local execution requests_ on the node receiving the message. 
 Historical queries use a _transaction hash_ as a point of reference to avoid race conditions and to allow asynchronous query execution.
 
 Pact code doesn't distinguish between transactional execution and local execution.
 However, the Pact API provides separate endpoints to execute transactions on the blockchain and submit local execution requests.
-FOr more information about using the Pact API endpoints, see [Pact API](/api/pact-api).
+For more information about using the Pact API endpoints, see [Pact API](/api/pact-api).
 
 

--- a/docs/smart-contracts/get-started-intro.md
+++ b/docs/smart-contracts/get-started-intro.md
@@ -16,7 +16,7 @@ To get started, it's important to know what smart contracts are and the kinds of
 A smart contract is a program that can automatically execute agreements—in the form of transactions—on the blockchain without any external oversight.
 The contract ensures that the specific conditions, defined in the code logic to describe the terms of the agreement, are met before executing the transaction programmatically.
 Smart contracts are deployed and executed on blockchain networks because the blockchain provides a decentralized, immutable, and publicly accessible record of all transactions.
-This transparency and traceability ensures that the programmatic execution of the contract can been considered trustworthy and verifiable.
+This transparency and traceability ensures that the programmatic execution of the contract can be considered trustworthy and verifiable.
 
 However, there are several unique challenges involved in writing smart contracts.
 For example, it's important to ensure that smart contracts can't be accessed by unauthorized parties, that transactions can't be intercepted or manipulated, and that code execution and data storage don't overload blockchain resources.

--- a/docs/smart-contracts/install.md
+++ b/docs/smart-contracts/install.md
@@ -22,7 +22,7 @@ At a high level, you complete the following steps to configure a development env
 
 ## Before you begin
 
-To prepare for installation, you should verify your development environment meets the following basic requirements
+To prepare for installation, you should verify your development environment meets the following basic requirements:
 
 - You have an internet connection and a web browser installed on your local computer.
 - You have an integrated development environment (IDE) or code editor such as [Visual Studio Code](https://code.visualstudio.com/download).


### PR DESCRIPTION
## Summary
- Fixed various spelling mistakes, grammatical errors, and punctuation issues across 10 documentation files
- Improved readability and professionalism of the documentation
- Corrected typos, verb tenses, article usage, and sentence structure

## Files Modified
- `docs/coding-projects/hello-world.md` - Fixed missing space after comma
- `docs/guides/contracts/deploy-a-contract.md` - Fixed punctuation and typo ("you" → "your")
- `docs/guides/dev-with-cli.md` - Fixed capitalization, grammar, and command example
- `docs/pact-5/general/enforce-guard.md` - Added missing space in compound word
- `docs/quickstart.md` - Fixed missing verb and corrected numbered list
- `docs/reference/exchange-integration.md` - Fixed multiple grammatical errors and typos
- `docs/resources/contribute-doc.md` - Added missing code block closure
- `docs/smart-contracts/basic-concepts.md` - Fixed verb agreement and multiple typos
- `docs/smart-contracts/get-started-intro.md` - Fixed verb form ("been" → "be")
- `docs/smart-contracts/install.md` - Added missing colon

## Test Plan
- [x] Reviewed all changes for accuracy
- [x] Verified no functionality or meaning changes
- [x] Confirmed proper formatting maintained

🤖 Generated with [Claude Code](https://claude.ai/code)